### PR TITLE
fix: as node:lts-alpine was bumped to alpine 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:lts-alpine
-RUN apk add --no-cache py3-pip bash git make ca-certificates
+RUN apk add --no-cache python3 bash git make ca-certificates
 RUN npm install -g aws-cdk
 COPY entrypoint.sh /entrypoint
 RUN chmod +x /entrypoint


### PR DESCRIPTION
Starting today looks like that the `node:lts-alpine` has bumped their base image to use alpine 3.11 and as such collateral effect the following error began to occurs:

```
apk add make
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  py3-pip (virtual):
    provided by: python3
    required by: world[py3-pip]
```

To fix that, we need to install only the `python3` package instead of `py3-pip`